### PR TITLE
Remove green background from log

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (config) {
     }
 
     http.createServer(app).listen(config.port, config.hostname, function () {
-      util.log(util.colors.bgGreen('Server started on ' + config.port + ' port'));
+      util.log('Server started on ' + config.port + ' port');
     });
   };
 };


### PR DESCRIPTION
The green background is pretty glaring, and can be hard to read if you have a dark terminal theme. Since none of the other gulp output has a background set, it seems out or place.