### PR TITLE
Remove dependency on deprecated gulp-util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 var http = require('http');
 var https = require('https');
 var fs = require('fs');
+var colors = require('ansi-colors');
+var log = require('fancy-log');
 var path = require('path');
-var util = require('gulp-util');
 var connect = require('connect');
 var serveStatic = require('serve-static');
 
@@ -59,7 +60,7 @@ module.exports = function (config) {
       var address = addr.address;
       var port = addr.port;
       var scheme = 'http' + (config.https ? 's' : '');
-      util.log(util.colors.blue('Server started at ' + scheme + '://' + address + ':' + port));
+      log(colors.blueBright('Server started at ' + scheme + '://' + address + ':' + port));
     };
 
     if (config.https) {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "connect": "^3.4.1",
-    "gulp-util": "^3.0.7",
+    "fancy-log": "^1.3.3",
     "serve-static": "^1.11.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The gulp-util is now deprecated: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5